### PR TITLE
Add ImportError handling & UTF-8 support

### DIFF
--- a/TheMarker.py
+++ b/TheMarker.py
@@ -1,7 +1,26 @@
-﻿import feedparser, os, pdb
-from yattag import Doc,indent
-from lxml import html
-import requests
+
+import os
+import pdb
+try:
+    import feedparser
+except ImportError:
+    print("Error: FeedParser not installed\nInstall using: pip install feedparser")
+    exit()
+try:
+    from yattag import Doc, indent
+except ImportError:
+    print("Error: yattag not installed\nInstall using: pip install yattag")
+    exit()
+try:
+    from lxml import html
+except ImportError:
+    print("Error: lxml not installed\nInstall using: pip install lxml")
+    exit()
+try:
+    import requests
+except ImportError:
+    print("Error: requests not installed\nInstall using: pip install requests")
+    exit()
 
 rss = raw_input("""Enter your preferred feed:
 1 - כל פרשנויות היום

--- a/TheMarker.py
+++ b/TheMarker.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 
 import os
 import pdb

--- a/TheMarker.py
+++ b/TheMarker.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+from builtins import input
 import os
 import pdb
 try:
@@ -23,7 +25,7 @@ except ImportError:
     print("Error: requests not installed\nInstall using: pip install requests")
     exit()
 
-rss = raw_input("""Enter your preferred feed:
+rss = input("""Enter your preferred feed:
 1 - כל פרשנויות היום
 2 - כל כותרות היום
 3 - כותרות דף הבית
@@ -36,12 +38,12 @@ elif rss=="2":
 else:
     themarker = "http://www.themarker.com/cmlink/1.145"
 
-#print themarker
+# print(themarker)
 
 d = feedparser.parse(themarker)
 
-#Title of Service
-#print d['feed']['title']
+# Title of Service
+# print(d['feed']['title'])
 
 ##Basic HTML template
 doc,tag,text= Doc().tagtext()
@@ -87,4 +89,4 @@ Html_file.close()
 
 os.startfile(Html_file.name, 'open')
 
-#print "DONE"
+# print("DONE")


### PR DESCRIPTION
Imports now catch errors for the modules:
- feedparser
- yattag
- lxml
- requests
as they are not installed with many regular python installations.
Error messages give hints towards installation of the modules with `pip install`.

Also a magic comment for UTF-8 support for Python 2.7 is added.